### PR TITLE
Add Grafana Riotization Logic for Alerts

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/tsdb/mqe"
 	_ "github.com/grafana/grafana/pkg/tsdb/opentsdb"
 	_ "github.com/grafana/grafana/pkg/tsdb/prometheus"
+	_ "github.com/grafana/grafana/pkg/tsdb/riot"
 	_ "github.com/grafana/grafana/pkg/tsdb/testdata"
 )
 

--- a/pkg/tsdb/riot/gmetricsd.go
+++ b/pkg/tsdb/riot/gmetricsd.go
@@ -1,0 +1,117 @@
+package riot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/tsdb"
+)
+
+type GMetricsdExecutor struct {
+	*models.DataSource
+	HttpClient *http.Client
+}
+
+func NewGMetricsdExecutor(dsInfo *models.DataSource) (tsdb.Executor, error) {
+	client, err := dsInfo.GetHttpClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &GMetricsdExecutor{
+		DataSource: dsInfo,
+		HttpClient: client,
+	}, nil
+}
+
+func (e *GMetricsdExecutor) buildRequest(queryInfo *tsdb.Query, timeRange *tsdb.TimeRange) (*http.Request, error) {
+
+	if queryInfo.Model == nil {
+		return nil, fmt.Errorf("Invalid (nil) GMetricsd Request Model Provided!")
+	}
+
+	requestModel := &GMetricsdRequestModel{}
+	rawModel, err := queryInfo.Model.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(rawModel, requestModel)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := url.Parse(queryInfo.DataSource.Url)
+	if err != nil {
+		return nil, err
+	}
+
+	if queryInfo.DataSource.BasicAuth {
+		parsedURL.User = url.UserPassword(queryInfo.DataSource.BasicAuthUser, queryInfo.DataSource.BasicAuthPassword)
+	}
+
+	requestURL := fmt.Sprintf("%s/v1/api/metric/history?uuid=%s&start=%d&end=%d&numslices=100", parsedURL.String(), requestModel.Metric.UUID, timeRange.GetFromAsMsEpoch()/1000, timeRange.GetToAsMsEpoch()/1000)
+	req, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (e *GMetricsdExecutor) Execute(ctx context.Context, queries tsdb.QuerySlice, context *tsdb.QueryContext) *tsdb.BatchResult {
+	result := &tsdb.BatchResult{}
+	result.QueryResults = make(map[string]*tsdb.QueryResult)
+
+	if context == nil {
+		return result.WithError(fmt.Errorf("Nil Context provided to GMetricsdExecutor"))
+	}
+
+	for _, q := range context.Queries {
+		if q.DataSource == nil {
+			return result.WithError(fmt.Errorf("Invalid (nil) DataSource Provided"))
+		}
+
+		if q.DataSource.JsonData == nil {
+			return result.WithError(fmt.Errorf("Invalid (nil) JsonData Provided"))
+		}
+
+		request, err := e.buildRequest(q, context.TimeRange)
+		if err != nil {
+			return result.WithError(err)
+		}
+
+		resp, err := e.HttpClient.Do(request)
+		if err != nil {
+			return result.WithError(err)
+		}
+		defer resp.Body.Close()
+
+		rBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return result.WithError(fmt.Errorf("Failed to read response body (%s): %s", strconv.Quote(string(rBody)), err))
+		}
+
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+			return result.WithError(fmt.Errorf("Failed to get metrics: %s (%s)", strconv.Quote(string(rBody)), resp.Status))
+		}
+
+		gmetricsdHistory := &GMetricsdHistoryResponse{}
+		err = json.Unmarshal(rBody, gmetricsdHistory)
+
+		parsedQueryResult, err := gmetricsdHistory.ToTsdbQueryResult()
+		if err != nil {
+			return result.WithError(fmt.Errorf("Failed to parse gmetricsd history response: %s", err.Error()))
+		}
+		parsedQueryResult.RefId = q.RefId
+		result.QueryResults[q.RefId] = parsedQueryResult
+	}
+
+	return result
+}

--- a/pkg/tsdb/riot/gmetricsd_test.go
+++ b/pkg/tsdb/riot/gmetricsd_test.go
@@ -197,7 +197,6 @@ func TestGmetricsdExecutorConstructor(t *testing.T) {
 						RefId: "A",
 						DataSource: &models.DataSource{
 							Url:               "http://test",
-							Database:          "[test-index-]YYYY.MM.DD",
 							Id:                1,
 							JsonData:          jsonData,
 							BasicAuth:         true,

--- a/pkg/tsdb/riot/gmetricsd_test.go
+++ b/pkg/tsdb/riot/gmetricsd_test.go
@@ -1,0 +1,222 @@
+package riot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/tsdb"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var testGmetricsdResponse = `{
+  "Metadata": {
+   "ResponseTime": "28.83327ms"
+  },
+  "History": {
+   "Uuid": "222495028366932659",
+   "TimeSeries": {
+    "1487342347": {
+     "StartTime": "1487342347",
+     "EndTime": "1487342347",
+     "Min": {
+      "Timestamp": "1487342347",
+      "Value": 0.0726
+     },
+     "Max": {
+      "Timestamp": "1487342347",
+      "Value": 0.0726
+     },
+     "Average": 0.0726,
+     "Midrange": 0.0726,
+     "NumberOfDataPoints": 1
+    },
+    "1487342423": {
+     "StartTime": "1487342423",
+     "EndTime": "1487342423",
+     "Min": {
+      "Timestamp": "1487342423",
+      "Value": 0.0815
+     },
+     "Max": {
+      "Timestamp": "1487342423",
+      "Value": 0.0815
+     },
+     "Average": 0.0815,
+     "Midrange": 0.0815,
+     "NumberOfDataPoints": 1
+    },
+    "1487342502": {
+     "StartTime": "1487342502",
+     "EndTime": "1487342502",
+     "Min": {
+      "Timestamp": "1487342502",
+      "Value": 0.1001
+     },
+     "Max": {
+      "Timestamp": "1487342502",
+      "Value": 0.1001
+     },
+     "Average": 0.1001,
+     "Midrange": 0.1001,
+     "NumberOfDataPoints": 1
+    },
+    "1487342580": {
+     "StartTime": "1487342580",
+     "EndTime": "1487342580",
+     "Min": {
+      "Timestamp": "1487342580",
+      "Value": 0.0751
+     },
+     "Max": {
+      "Timestamp": "1487342580",
+      "Value": 0.0751
+     },
+     "Average": 0.0751,
+     "Midrange": 0.0751,
+     "NumberOfDataPoints": 1
+    },
+    "1487342657": {
+     "StartTime": "1487342657",
+     "EndTime": "1487342657",
+     "Min": {
+      "Timestamp": "1487342657",
+      "Value": 0.0566
+     },
+     "Max": {
+      "Timestamp": "1487342657",
+      "Value": 0.0566
+     },
+     "Average": 0.0566,
+     "Midrange": 0.0566,
+     "NumberOfDataPoints": 1
+    },
+    "1487342738": {
+     "StartTime": "1487342738",
+     "EndTime": "1487342738",
+     "Min": {
+      "Timestamp": "1487342738",
+      "Value": 0.0635
+     },
+     "Max": {
+      "Timestamp": "1487342738",
+      "Value": 0.0635
+     },
+     "Average": 0.0635,
+     "Midrange": 0.0635,
+     "NumberOfDataPoints": 1
+    },
+    "1487342818": {
+     "StartTime": "1487342818",
+     "EndTime": "1487342818",
+     "Min": {
+      "Timestamp": "1487342818",
+      "Value": 0.1037
+     },
+     "Max": {
+      "Timestamp": "1487342818",
+      "Value": 0.1037
+     },
+     "Average": 0.1037,
+     "Midrange": 0.1037,
+     "NumberOfDataPoints": 1
+    },
+    "1487342897": {
+     "StartTime": "1487342897",
+     "EndTime": "1487342897",
+     "Min": {
+      "Timestamp": "1487342897",
+      "Value": 0.0557
+     },
+     "Max": {
+      "Timestamp": "1487342897",
+      "Value": 0.0557
+     },
+     "Average": 0.0557,
+     "Midrange": 0.0557,
+     "NumberOfDataPoints": 1
+    }
+   },
+   "PrettyName": "grpavg:TELEMETRY.ALERTEROUS.pipeline.watcher.create.rate1",
+   "Name": "grpavg[\"metricsd_globalriot.las2.alerterous1_TELEMETRY.ALERTEROUS\",\"metricsd[\\\"TELEMETRY.ALERTEROUS.pipeline.watcher.create.rate1\\\"]\", avg, 90s]",
+   "Host": {
+    "Hostname": "metricsd_globalriot.las2.alerterous1_TELEMETRY.ALERTEROUS",
+    "Hostid": "11447"
+   }
+  }
+ }`
+
+func TestGmetricsdParseResponse(t *testing.T) {
+	Convey("Test Parse GMetricsd Response", t, func() {
+		Convey("Parse Response into tsdb Response", func() {
+			history := &GMetricsdHistoryResponse{}
+
+			err := json.Unmarshal([]byte(testGmetricsdResponse), history)
+			So(err, ShouldBeNil)
+
+			So(history.History.Host.Hostname, ShouldEqual, "metricsd_globalriot.las2.alerterous1_TELEMETRY.ALERTEROUS")
+			So(history.History.PrettyName, ShouldEqual, "grpavg:TELEMETRY.ALERTEROUS.pipeline.watcher.create.rate1")
+			So(len(history.History.TimeSeries), ShouldEqual, 8)
+
+			tsdbQueryResult, err := history.ToTsdbQueryResult()
+			So(tsdbQueryResult, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			So(len(tsdbQueryResult.Series[0].Points), ShouldEqual, 8)
+			So(tsdbQueryResult.Series[0].Name, ShouldEqual, fmt.Sprintf("%s [%s]", history.History.PrettyName, history.History.Host.Hostname))
+		})
+	})
+}
+
+func TestGmetricsdExecutorConstructor(t *testing.T) {
+	Convey("Test Parse GMetricsdExecutor", t, func() {
+		Convey("Construct", func() {
+			ds := &models.DataSource{
+				BasicAuth:         true,
+				BasicAuthUser:     "test-user",
+				BasicAuthPassword: "test-password",
+			}
+
+			e, err := NewGMetricsdExecutor(ds)
+			So(err, ShouldBeNil)
+
+			var ctx context.Context
+			result := e.Execute(ctx, nil, nil)
+			So(result.Error, ShouldNotBeNil)
+
+			modelJson, _ := simplejson.NewJson([]byte(`{}`))
+
+			jsonData, _ := simplejson.NewJson([]byte(`{}`))
+			queryContext := &tsdb.QueryContext{
+				Queries: tsdb.QuerySlice{
+					{
+						RefId: "A",
+						DataSource: &models.DataSource{
+							Url:               "http://test",
+							Database:          "[test-index-]YYYY.MM.DD",
+							Id:                1,
+							JsonData:          jsonData,
+							BasicAuth:         true,
+							BasicAuthUser:     "test-user",
+							BasicAuthPassword: "test-password",
+						},
+						Model: modelJson,
+					},
+				},
+				TimeRange: &tsdb.TimeRange{
+					From: "5m",
+					To:   "now",
+					Now:  time.Now(),
+				},
+			}
+
+			result = e.Execute(ctx, queryContext.Queries, queryContext)
+			So(result.Error, ShouldNotBeNil)
+		})
+
+	})
+}

--- a/pkg/tsdb/riot/riot.go
+++ b/pkg/tsdb/riot/riot.go
@@ -1,0 +1,18 @@
+package riot
+
+import (
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/tsdb"
+	"github.com/grafana/grafana/pkg/tsdb/elasticsearch"
+)
+
+var (
+	riotlog log.Logger
+)
+
+func init() {
+	riotlog = log.New("tsdb.riot")
+
+	tsdb.RegisterExecutor("riotelasticsearch", elasticsearch.NewElasticsearchExecutor)
+	tsdb.RegisterExecutor("gmetricsd", NewGMetricsdExecutor)
+}

--- a/pkg/tsdb/riot/types.go
+++ b/pkg/tsdb/riot/types.go
@@ -1,0 +1,84 @@
+package riot
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana/pkg/tsdb"
+)
+
+type MetricObject struct {
+	UUID string
+}
+
+type GMetricsdRequestModel struct {
+	Metric MetricObject `json:"metricObject"`
+}
+
+type DataPointValue struct {
+	Timestamp string
+	Value     interface{}
+}
+
+type DataPoint struct {
+	StartTime          string
+	EndTime            string
+	Min                DataPointValue
+	Max                DataPointValue
+	Average            interface{}
+	Midrange           interface{}
+	NumberOfDataPoints int
+}
+
+type HistoryObject struct {
+	UUID       string `json:"Uuid"`
+	TimeSeries map[string]DataPoint
+	PrettyName string
+	Name       string
+	Host       Host
+}
+
+type Host struct {
+	Hostname string
+	Hostid   string
+}
+
+type GMetricsdHistoryResponse struct {
+	History HistoryObject
+}
+
+func (history *GMetricsdHistoryResponse) ToTsdbQueryResult() (*tsdb.QueryResult, error) {
+	queryRes := tsdb.NewQueryResult()
+
+	var points tsdb.TimeSeriesPoints
+	for ts, data := range history.History.TimeSeries {
+		var valueRow [2]null.Float
+		fValue, ok := data.Average.(float64)
+		if !ok {
+			continue
+		}
+		valueRow[0] = parseValue(fValue)
+
+		tsFloat, err := strconv.ParseFloat(ts, 64)
+		if err != nil {
+			riotlog.Error(fmt.Sprintf("Error parsing timestamp in gmetricsd alert handler: %s", err.Error()))
+			continue
+		}
+		valueRow[1] = parseValue(tsFloat)
+
+		points = append(points, valueRow)
+	}
+
+	ts := &tsdb.TimeSeries{
+		Name:   fmt.Sprintf("%s [%s]", history.History.PrettyName, history.History.Host.Hostname),
+		Points: points,
+	}
+
+	queryRes.Series = append(queryRes.Series, ts)
+	return queryRes, nil
+}
+
+func parseValue(value float64) null.Float {
+	return null.FloatFrom(float64(value))
+}


### PR DESCRIPTION
This commit allows us to make use of alerting with a custom aggregation datasource (Gmetricsd) and an enhanced elasticsearch plugin `RiotElasticsearch`.


