### PR TITLE
Modifying backend elasticsearch query builder to include aggregate logic

### DIFF
--- a/pkg/tsdb/elasticsearch/query_builder.go
+++ b/pkg/tsdb/elasticsearch/query_builder.go
@@ -1,63 +1,67 @@
 package elasticsearch
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"strconv"
-	"time"
+  "bytes"
+  "encoding/json"
+  "fmt"
+  "strconv"
+  "time"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/tsdb"
+  "github.com/grafana/grafana/pkg/components/simplejson"
+  "github.com/grafana/grafana/pkg/tsdb"
 
-	"text/template"
+  "text/template"
 )
 
 // TemplateQueryModel provides the data container used by the elasticsearch JSON template
 type TemplateQueryModel struct {
-	TimeRange *tsdb.TimeRange
-	Model     *RequestModel
+  TimeRange *tsdb.TimeRange
+  Model     *RequestModel
 }
 
 var queryTemplate = `
 {
   "size": 0,
   "query": {
-    "bool": {
-      "filter": [
-        {
-          "range": {{ . | formatTimeRange }}
-        },
-        {
-          "query_string": {
-            "analyze_wildcard": true,
-            "query": {{ marshal .Model.Query }}
-          }
+    "filtered": {
+      "query": {
+        "query_string": {
+          "analyze_wildcard": true,
+          "query": {{ marshal .Model.Query }}
         }
-      ]
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {{ . | formatTimeRange }}
+            }
+          ]
+        }
+      }
     }
   },
   "aggs": {{ . | formatAggregates }}
 }`
 
 func convertTimeToUnixNano(rangeTime string, now time.Time) string {
-	if rangeTime == "now" {
-		rangeTime = "30s"
-	}
+  if rangeTime == "now" {
+    rangeTime = "30s"
+  }
 
-	duration, err := time.ParseDuration(fmt.Sprintf("-%s", rangeTime))
-	if err != nil {
-		return err.Error()
-	}
+  duration, err := time.ParseDuration(fmt.Sprintf("-%s", rangeTime))
+  if err != nil {
+    return err.Error()
+  }
 
-	return strconv.FormatInt(now.Add(duration).UnixNano()/1000/1000, 10)
+  return strconv.FormatInt(now.Add(duration).UnixNano()/1000/1000, 10)
 }
 
 func formatTimeRange(data TemplateQueryModel) string {
-	to := convertTimeToUnixNano(data.TimeRange.To, data.TimeRange.Now)
-	from := convertTimeToUnixNano(data.TimeRange.From, data.TimeRange.Now)
+  to := convertTimeToUnixNano(data.TimeRange.To, data.TimeRange.Now)
+  from := convertTimeToUnixNano(data.TimeRange.From, data.TimeRange.Now)
 
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
     {
       "%s": {
         "gte":"%s",
@@ -68,88 +72,195 @@ func formatTimeRange(data TemplateQueryModel) string {
 }
 
 func formatAggregates(data TemplateQueryModel) string {
-	aggregates := simplejson.New()
+  // Port of ElasticSearch query builder frontend datasource logic
+  nestedAggs := simplejson.New()
+  result := nestedAggs
+  for _, bAgg := range data.Model.BucketAggregates {
+    innerAgg := simplejson.New()
+    switch bAgg.Type {
+    case "date_histogram":
+      innerAgg.Set("date_histogram", createDateHistogramAgg(&bAgg, data.TimeRange, data.Model.TimeField))
+    case "filters":
+      innerAgg.Set("filters", createFiltersAgg(&bAgg))
+    case "terms":
+      buildTermsAgg(&bAgg, innerAgg, data)
+    case "geohash_grid":
+      innerAgg.Set("geohash_grid", createGeohashAgg(&bAgg))
+    }
+    aggsVal, exists := nestedAggs.CheckGet("aggs")
+    if !exists {
+      aggsVal = simplejson.New()
+      nestedAggs.Set("aggs", aggsVal)
+    }
+    aggsVal.Set(bAgg.ID, innerAgg)
+    nestedAggs = innerAgg
+  }
 
-	for _, bAgg := range data.Model.BucketAggregates {
-		bucket := simplejson.New()
+  innermostAggs := simplejson.New()
+  nestedAggs.Set("aggs", innermostAggs)
 
-		bucketAggregates := simplejson.New()
-		bucketAggregates.Set("field", bAgg.Field)
+  for _, metric := range data.Model.Metrics {
+    if metric.Type == "count" {
+      continue
+    }
 
-		for key, value := range bAgg.Settings {
-			if key == "trimEdges" {
-				continue
-			} else if key == "interval" {
-				if value == "auto" {
-					value = "5s"
-				}
-				bucketAggregates.Set(key, value)
-			} else {
-				bucketAggregates.Set(key, value)
-			}
-		}
+    aggField := simplejson.New()
+    metricAgg := simplejson.New()
 
-		extendedBounds := simplejson.New()
-		extendedBounds.Set("min", convertTimeToUnixNano(data.TimeRange.From, data.TimeRange.Now))
-		extendedBounds.Set("max", convertTimeToUnixNano(data.TimeRange.To, data.TimeRange.Now))
-		bucketAggregates.Set("extended_bounds", extendedBounds.MustMap())
+    if isPipelineAgg(metric.Type) {
+      if pipelineAgg, err := strconv.Atoi(metric.PipelineAggregate); err == nil {
+        metricAgg.Set("buckets_path", fmt.Sprintf("%d", pipelineAgg))
+      } else {
+        continue
+      }
+    } else {
+      metricAgg.Set("field", metric.Field)
+    }
 
-		bucketAggregates.Set("format", "epoch_millis")
-		bucket.Set(bAgg.Type, bucketAggregates.MustMap())
+    for setting, settingVal  := range(metric.Settings) {
+      metricAgg.Set(setting, settingVal)
+    }
 
-		metricAggregates := simplejson.New()
-		for _, metric := range data.Model.Metrics {
-			metricAggregate := simplejson.New()
+    aggField.Set(metric.Type, metricAgg)
+    innermostAggs.Set(metric.ID, aggField)
+  }
 
-			aggregate := simplejson.New()
-			for key, value := range metric.Settings {
-				aggregate.Set(key, value)
-			}
+  aggString, err := result.Get("aggs").MarshalJSON()
+  if err != nil {
+    eslog.Error("%s %s\n", string(aggString), err.Error())
+  }
+  return string(aggString)
+}
 
-			if metric.PipelineAggregate == "" {
-				aggregate.Set("field", metric.Field)
-			} else {
-				aggregate.Set("buckets_path", metric.Field)
-			}
+func _helperSetFieldInJsonFromMap(json *simplejson.Json, settingsMap map[string]interface{}, settingName string,
+defaultValue interface{}) {
+  if val, exists := settingsMap[settingName]; exists {
+    json.Set(settingName, val)
+  } else if defaultValue != nil {
+    json.Set(settingName, defaultValue)
+  }
+}
 
-			metricAggregate.Set(metric.Type, aggregate)
-			metricAggregates.Set(metric.ID, metricAggregate.MustMap())
-		}
-		bucket.Set("aggs", metricAggregates.MustMap())
+func createDateHistogramAgg(bAgg *BucketAggregate, timeRange *tsdb.TimeRange, defaultTimeField string) *simplejson.Json {
+  result := simplejson.New()
+  if (bAgg.Settings != nil) {
+    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "interval", nil)
+    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", 0)
+    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
+  }
 
-		aggregates.Set(bAgg.ID, bucket.MustMap())
-	}
+  result.Set("field", defaultTimeField)
 
-	aggString, err := aggregates.MarshalJSON()
-	if err != nil {
-		eslog.Error("%s %s\n", string(aggString), err.Error())
-	}
-	return string(aggString)
+  extendedBounds := simplejson.New()
+  extendedBounds.Set("min", convertTimeToUnixNano(timeRange.From, timeRange.Now))
+  extendedBounds.Set("max", convertTimeToUnixNano(timeRange.To, timeRange.Now))
+  result.Set("extended_bounds", extendedBounds)
+
+  result.Set("format", "epoch_millis")
+
+  if interval, _ := result.Get("interval").String(); interval == "auto" {
+    result.Set("interval", tsdb.CalculateInterval(timeRange).Text)
+  }
+
+  return result
+}
+
+func createFiltersAgg(bAgg *BucketAggregate) *simplejson.Json {
+  result := simplejson.New()
+  for _, filter := range bAgg.Settings["filters"].([]map[string]interface{}) {
+    if query, exists := filter["query"]; exists {
+      queryObjJson := simplejson.New()
+      queryStringJson := simplejson.New()
+      queryStringJson.Set("query", query)
+      queryStringJson.Set("analyze_wildcard", true)
+      queryObjJson.Set("query_string", queryStringJson)
+      result.Set(query.(string), queryObjJson)
+    }
+  }
+  return result
+}
+
+func buildTermsAgg(bAgg *BucketAggregate, queryNode *simplejson.Json, data TemplateQueryModel) {
+  result := simplejson.New()
+  result.Set("field", bAgg.Field)
+  queryNode.Set("terms", result)
+
+  if bAgg.Settings == nil {
+    return
+  }
+
+  if size, err := strconv.Atoi(bAgg.Settings["size"].(string)); err == nil {
+    if (size == 0) {
+      result.Set("size", 500)
+    } else {
+      result.Set("size", size)
+    }
+  }
+  if orderBy, exists := bAgg.Settings["orderBy"]; exists {
+    orderJson := simplejson.New()
+    if order, exists := bAgg.Settings["order"]; exists {
+      orderJson.Set(orderBy.(string), order)
+    }
+    result.Set("order", orderJson)
+
+    _, err := strconv.Atoi(orderBy.(string))
+    if err == nil {
+      for _, metric := range(data.Model.Metrics) {
+        if (metric.ID == orderBy) {
+          aggJson := simplejson.New()
+          queryNode.Set("aggs", aggJson)
+          metricAggJson := simplejson.New()
+          metricAggJson.Set("field", metric.Field)
+          aggJson.Set(metric.Type, metricAggJson)
+          break
+        }
+      }
+    }
+
+    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", nil)
+    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
+  }
+}
+
+func createGeohashAgg(bAgg *BucketAggregate) *simplejson.Json {
+  geohashJson := simplejson.New()
+  geohashJson.Set("field", bAgg.Field)
+  geohashJson.Set("precision", bAgg.Settings["precision"])
+  return geohashJson
+}
+
+func isPipelineAgg(metricType string) bool {
+  // Taken from pipeline options in the Elasticsearch query definition
+  switch metricType {
+  case "moving_avg", "derivative":
+    return true
+  }
+  return false
 }
 
 func (model *RequestModel) buildQueryJSON(timeRange *tsdb.TimeRange) (string, error) {
 
-	templateQueryModel := TemplateQueryModel{
-		TimeRange: timeRange,
-		Model:     model,
-	}
+  templateQueryModel := TemplateQueryModel{
+    TimeRange: timeRange,
+    Model:     model,
+  }
 
-	funcMap := template.FuncMap{
-		"formatTimeRange":  formatTimeRange,
-		"formatAggregates": formatAggregates,
-		"marshal": func(v interface{}) string {
-			a, _ := json.Marshal(v)
-			return string(a)
-		},
-	}
+  funcMap := template.FuncMap{
+    "formatTimeRange":  formatTimeRange,
+    "formatAggregates": formatAggregates,
+    "marshal": func(v interface{}) string {
+      a, _ := json.Marshal(v)
+      return string(a)
+    },
+  }
 
-	t, err := template.New("elasticsearchQuery").Funcs(funcMap).Parse(queryTemplate)
-	if err != nil {
-		return "", err
-	}
+  t, err := template.New("elasticsearchQuery").Funcs(funcMap).Parse(queryTemplate)
+  if err != nil {
+    return "", err
+  }
 
-	buffer := bytes.NewBufferString("")
-	t.Execute(buffer, templateQueryModel)
+  buffer := bytes.NewBufferString("")
+  t.Execute(buffer, templateQueryModel)
 
-	return string(buffer.Bytes()), nil
+  return string(buffer.Bytes()), nil
 }

--- a/pkg/tsdb/elasticsearch/query_builder.go
+++ b/pkg/tsdb/elasticsearch/query_builder.go
@@ -1,266 +1,266 @@
 package elasticsearch
 
 import (
-  "bytes"
-  "encoding/json"
-  "fmt"
-  "strconv"
-  "time"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
 
-  "github.com/grafana/grafana/pkg/components/simplejson"
-  "github.com/grafana/grafana/pkg/tsdb"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
 
-  "text/template"
+	"text/template"
 )
 
 // TemplateQueryModel provides the data container used by the elasticsearch JSON template
 type TemplateQueryModel struct {
-  TimeRange *tsdb.TimeRange
-  Model     *RequestModel
+	TimeRange *tsdb.TimeRange
+	Model     *RequestModel
 }
 
 var queryTemplate = `
 {
-  "size": 0,
-  "query": {
-    "filtered": {
-      "query": {
-        "query_string": {
-          "analyze_wildcard": true,
-          "query": {{ marshal .Model.Query }}
-        }
-      },
-      "filter": {
-        "bool": {
-          "must": [
-            {
-              "range": {{ . | formatTimeRange }}
-            }
-          ]
-        }
-      }
-    }
-  },
-  "aggs": {{ . | formatAggregates }}
+	"size": 0,
+	"query": {
+		"filtered": {
+			"query": {
+				"query_string": {
+					"analyze_wildcard": true,
+					"query": {{ marshal .Model.Query }}
+				}
+			},
+			"filter": {
+				"bool": {
+					"must": [
+						{
+							"range": {{ . | formatTimeRange }}
+						}
+					]
+				}
+			}
+		}
+	},
+	"aggs": {{ . | formatAggregates }}
 }`
 
 func convertTimeToUnixNano(rangeTime string, now time.Time) string {
-  if rangeTime == "now" {
-    rangeTime = "30s"
-  }
+	if rangeTime == "now" {
+		rangeTime = "30s"
+	}
 
-  duration, err := time.ParseDuration(fmt.Sprintf("-%s", rangeTime))
-  if err != nil {
-    return err.Error()
-  }
+	duration, err := time.ParseDuration(fmt.Sprintf("-%s", rangeTime))
+	if err != nil {
+		return err.Error()
+	}
 
-  return strconv.FormatInt(now.Add(duration).UnixNano()/1000/1000, 10)
+	return strconv.FormatInt(now.Add(duration).UnixNano()/1000/1000, 10)
 }
 
 func formatTimeRange(data TemplateQueryModel) string {
-  to := convertTimeToUnixNano(data.TimeRange.To, data.TimeRange.Now)
-  from := convertTimeToUnixNano(data.TimeRange.From, data.TimeRange.Now)
+	to := convertTimeToUnixNano(data.TimeRange.To, data.TimeRange.Now)
+	from := convertTimeToUnixNano(data.TimeRange.From, data.TimeRange.Now)
 
-  return fmt.Sprintf(`
-    {
-      "%s": {
-        "gte":"%s",
-        "lte":"%s",
-        "format":"epoch_millis"
-      }
-    }`, data.Model.TimeField, from, to)
+	return fmt.Sprintf(`
+		{
+			"%s": {
+				"gte":"%s",
+				"lte":"%s",
+				"format":"epoch_millis"
+			}
+		}`, data.Model.TimeField, from, to)
 }
 
 func formatAggregates(data TemplateQueryModel) string {
-  // Port of ElasticSearch query builder frontend datasource logic
-  nestedAggs := simplejson.New()
-  result := nestedAggs
-  for _, bAgg := range data.Model.BucketAggregates {
-    innerAgg := simplejson.New()
-    switch bAgg.Type {
-    case "date_histogram":
-      innerAgg.Set("date_histogram", createDateHistogramAgg(&bAgg, data.TimeRange, data.Model.TimeField))
-    case "filters":
-      innerAgg.Set("filters", createFiltersAgg(&bAgg))
-    case "terms":
-      buildTermsAgg(&bAgg, innerAgg, data)
-    case "geohash_grid":
-      innerAgg.Set("geohash_grid", createGeohashAgg(&bAgg))
-    }
-    aggsVal, exists := nestedAggs.CheckGet("aggs")
-    if !exists {
-      aggsVal = simplejson.New()
-      nestedAggs.Set("aggs", aggsVal)
-    }
-    aggsVal.Set(bAgg.ID, innerAgg)
-    nestedAggs = innerAgg
-  }
+	// Port of ElasticSearch query builder frontend datasource logic
+	nestedAggs := simplejson.New()
+	result := nestedAggs
+	for _, bAgg := range data.Model.BucketAggregates {
+		innerAgg := simplejson.New()
+		switch bAgg.Type {
+		case "date_histogram":
+			innerAgg.Set("date_histogram", createDateHistogramAgg(&bAgg, data.TimeRange, data.Model.TimeField))
+		case "filters":
+			innerAgg.Set("filters", createFiltersAgg(&bAgg))
+		case "terms":
+			buildTermsAgg(&bAgg, innerAgg, data)
+		case "geohash_grid":
+			innerAgg.Set("geohash_grid", createGeohashAgg(&bAgg))
+		}
+		aggsVal, exists := nestedAggs.CheckGet("aggs")
+		if !exists {
+			aggsVal = simplejson.New()
+			nestedAggs.Set("aggs", aggsVal)
+		}
+		aggsVal.Set(bAgg.ID, innerAgg)
+		nestedAggs = innerAgg
+	}
 
-  innermostAggs := simplejson.New()
-  nestedAggs.Set("aggs", innermostAggs)
+	innermostAggs := simplejson.New()
+	nestedAggs.Set("aggs", innermostAggs)
 
-  for _, metric := range data.Model.Metrics {
-    if metric.Type == "count" {
-      continue
-    }
+	for _, metric := range data.Model.Metrics {
+		if metric.Type == "count" {
+			continue
+		}
 
-    aggField := simplejson.New()
-    metricAgg := simplejson.New()
+		aggField := simplejson.New()
+		metricAgg := simplejson.New()
 
-    if isPipelineAgg(metric.Type) {
-      if pipelineAgg, err := strconv.Atoi(metric.PipelineAggregate); err == nil {
-        metricAgg.Set("buckets_path", fmt.Sprintf("%d", pipelineAgg))
-      } else {
-        continue
-      }
-    } else {
-      metricAgg.Set("field", metric.Field)
-    }
+		if isPipelineAgg(metric.Type) {
+			if pipelineAgg, err := strconv.Atoi(metric.PipelineAggregate); err == nil {
+				metricAgg.Set("buckets_path", fmt.Sprintf("%d", pipelineAgg))
+			} else {
+				continue
+			}
+		} else {
+			metricAgg.Set("field", metric.Field)
+		}
 
-    for setting, settingVal  := range(metric.Settings) {
-      metricAgg.Set(setting, settingVal)
-    }
+		for setting, settingVal := range metric.Settings {
+			metricAgg.Set(setting, settingVal)
+		}
 
-    aggField.Set(metric.Type, metricAgg)
-    innermostAggs.Set(metric.ID, aggField)
-  }
+		aggField.Set(metric.Type, metricAgg)
+		innermostAggs.Set(metric.ID, aggField)
+	}
 
-  aggString, err := result.Get("aggs").MarshalJSON()
-  if err != nil {
-    eslog.Error("%s %s\n", string(aggString), err.Error())
-  }
-  return string(aggString)
+	aggString, err := result.Get("aggs").MarshalJSON()
+	if err != nil {
+		eslog.Error("%s %s\n", string(aggString), err.Error())
+	}
+	return string(aggString)
 }
 
 func _helperSetFieldInJsonFromMap(json *simplejson.Json, settingsMap map[string]interface{}, settingName string,
-defaultValue interface{}) {
-  if val, exists := settingsMap[settingName]; exists {
-    json.Set(settingName, val)
-  } else if defaultValue != nil {
-    json.Set(settingName, defaultValue)
-  }
+	defaultValue interface{}) {
+	if val, exists := settingsMap[settingName]; exists {
+		json.Set(settingName, val)
+	} else if defaultValue != nil {
+		json.Set(settingName, defaultValue)
+	}
 }
 
 func createDateHistogramAgg(bAgg *BucketAggregate, timeRange *tsdb.TimeRange, defaultTimeField string) *simplejson.Json {
-  result := simplejson.New()
-  if (bAgg.Settings != nil) {
-    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "interval", nil)
-    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", 0)
-    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
-  }
+	result := simplejson.New()
+	if bAgg.Settings != nil {
+		_helperSetFieldInJsonFromMap(result, bAgg.Settings, "interval", nil)
+		_helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", 0)
+		_helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
+	}
 
-  result.Set("field", defaultTimeField)
+	result.Set("field", defaultTimeField)
 
-  extendedBounds := simplejson.New()
-  extendedBounds.Set("min", convertTimeToUnixNano(timeRange.From, timeRange.Now))
-  extendedBounds.Set("max", convertTimeToUnixNano(timeRange.To, timeRange.Now))
-  result.Set("extended_bounds", extendedBounds)
+	extendedBounds := simplejson.New()
+	extendedBounds.Set("min", convertTimeToUnixNano(timeRange.From, timeRange.Now))
+	extendedBounds.Set("max", convertTimeToUnixNano(timeRange.To, timeRange.Now))
+	result.Set("extended_bounds", extendedBounds)
 
-  result.Set("format", "epoch_millis")
+	result.Set("format", "epoch_millis")
 
-  if interval, _ := result.Get("interval").String(); interval == "auto" {
-    result.Set("interval", tsdb.CalculateInterval(timeRange).Text)
-  }
+	if interval, _ := result.Get("interval").String(); interval == "auto" {
+		result.Set("interval", tsdb.CalculateInterval(timeRange).Text)
+	}
 
-  return result
+	return result
 }
 
 func createFiltersAgg(bAgg *BucketAggregate) *simplejson.Json {
-  result := simplejson.New()
-  for _, filter := range bAgg.Settings["filters"].([]map[string]interface{}) {
-    if query, exists := filter["query"]; exists {
-      queryObjJson := simplejson.New()
-      queryStringJson := simplejson.New()
-      queryStringJson.Set("query", query)
-      queryStringJson.Set("analyze_wildcard", true)
-      queryObjJson.Set("query_string", queryStringJson)
-      result.Set(query.(string), queryObjJson)
-    }
-  }
-  return result
+	result := simplejson.New()
+	for _, filter := range bAgg.Settings["filters"].([]map[string]interface{}) {
+		if query, exists := filter["query"]; exists {
+			queryObjJson := simplejson.New()
+			queryStringJson := simplejson.New()
+			queryStringJson.Set("query", query)
+			queryStringJson.Set("analyze_wildcard", true)
+			queryObjJson.Set("query_string", queryStringJson)
+			result.Set(query.(string), queryObjJson)
+		}
+	}
+	return result
 }
 
 func buildTermsAgg(bAgg *BucketAggregate, queryNode *simplejson.Json, data TemplateQueryModel) {
-  result := simplejson.New()
-  result.Set("field", bAgg.Field)
-  queryNode.Set("terms", result)
+	result := simplejson.New()
+	result.Set("field", bAgg.Field)
+	queryNode.Set("terms", result)
 
-  if bAgg.Settings == nil {
-    return
-  }
+	if bAgg.Settings == nil {
+		return
+	}
 
-  if size, err := strconv.Atoi(bAgg.Settings["size"].(string)); err == nil {
-    if (size == 0) {
-      result.Set("size", 500)
-    } else {
-      result.Set("size", size)
-    }
-  }
-  if orderBy, exists := bAgg.Settings["orderBy"]; exists {
-    orderJson := simplejson.New()
-    if order, exists := bAgg.Settings["order"]; exists {
-      orderJson.Set(orderBy.(string), order)
-    }
-    result.Set("order", orderJson)
+	if size, err := strconv.Atoi(bAgg.Settings["size"].(string)); err == nil {
+		if size == 0 {
+			result.Set("size", 500)
+		} else {
+			result.Set("size", size)
+		}
+	}
+	if orderBy, exists := bAgg.Settings["orderBy"]; exists {
+		orderJson := simplejson.New()
+		if order, exists := bAgg.Settings["order"]; exists {
+			orderJson.Set(orderBy.(string), order)
+		}
+		result.Set("order", orderJson)
 
-    _, err := strconv.Atoi(orderBy.(string))
-    if err == nil {
-      for _, metric := range(data.Model.Metrics) {
-        if (metric.ID == orderBy) {
-          aggJson := simplejson.New()
-          queryNode.Set("aggs", aggJson)
-          metricAggJson := simplejson.New()
-          metricAggJson.Set("field", metric.Field)
-          aggJson.Set(metric.Type, metricAggJson)
-          break
-        }
-      }
-    }
+		_, err := strconv.Atoi(orderBy.(string))
+		if err == nil {
+			for _, metric := range data.Model.Metrics {
+				if metric.ID == orderBy {
+					aggJson := simplejson.New()
+					queryNode.Set("aggs", aggJson)
+					metricAggJson := simplejson.New()
+					metricAggJson.Set("field", metric.Field)
+					aggJson.Set(metric.Type, metricAggJson)
+					break
+				}
+			}
+		}
 
-    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", nil)
-    _helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
-  }
+		_helperSetFieldInJsonFromMap(result, bAgg.Settings, "min_doc_count", nil)
+		_helperSetFieldInJsonFromMap(result, bAgg.Settings, "missing", nil)
+	}
 }
 
 func createGeohashAgg(bAgg *BucketAggregate) *simplejson.Json {
-  geohashJson := simplejson.New()
-  geohashJson.Set("field", bAgg.Field)
-  geohashJson.Set("precision", bAgg.Settings["precision"])
-  return geohashJson
+	geohashJson := simplejson.New()
+	geohashJson.Set("field", bAgg.Field)
+	geohashJson.Set("precision", bAgg.Settings["precision"])
+	return geohashJson
 }
 
 func isPipelineAgg(metricType string) bool {
-  // Taken from pipeline options in the Elasticsearch query definition
-  switch metricType {
-  case "moving_avg", "derivative":
-    return true
-  }
-  return false
+	// Taken from pipeline options in the Elasticsearch query definition
+	switch metricType {
+	case "moving_avg", "derivative":
+		return true
+	}
+	return false
 }
 
 func (model *RequestModel) buildQueryJSON(timeRange *tsdb.TimeRange) (string, error) {
 
-  templateQueryModel := TemplateQueryModel{
-    TimeRange: timeRange,
-    Model:     model,
-  }
+	templateQueryModel := TemplateQueryModel{
+		TimeRange: timeRange,
+		Model:     model,
+	}
 
-  funcMap := template.FuncMap{
-    "formatTimeRange":  formatTimeRange,
-    "formatAggregates": formatAggregates,
-    "marshal": func(v interface{}) string {
-      a, _ := json.Marshal(v)
-      return string(a)
-    },
-  }
+	funcMap := template.FuncMap{
+		"formatTimeRange":  formatTimeRange,
+		"formatAggregates": formatAggregates,
+		"marshal": func(v interface{}) string {
+			a, _ := json.Marshal(v)
+			return string(a)
+		},
+	}
 
-  t, err := template.New("elasticsearchQuery").Funcs(funcMap).Parse(queryTemplate)
-  if err != nil {
-    return "", err
-  }
+	t, err := template.New("elasticsearchQuery").Funcs(funcMap).Parse(queryTemplate)
+	if err != nil {
+		return "", err
+	}
 
-  buffer := bytes.NewBufferString("")
-  t.Execute(buffer, templateQueryModel)
+	buffer := bytes.NewBufferString("")
+	t.Execute(buffer, templateQueryModel)
 
-  return string(buffer.Bytes()), nil
+	return string(buffer.Bytes()), nil
 }

--- a/pkg/tsdb/elasticsearch/query_builder_test.go
+++ b/pkg/tsdb/elasticsearch/query_builder_test.go
@@ -1,22 +1,21 @@
 package elasticsearch
 
 import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-	"strings"
-	"testing"
-	"time"
+  "encoding/json"
+  "reflect"
+  "strings"
+  "testing"
+  "time"
 
-	"github.com/grafana/grafana/pkg/tsdb"
-	. "github.com/smartystreets/goconvey/convey"
+  "github.com/grafana/grafana/pkg/tsdb"
+  . "github.com/smartystreets/goconvey/convey"
 )
 
-func TestElasticserachQueryBuilder(t *testing.T) {
-	Convey("Elasticserach QueryBuilder query testing", t, func() {
+func TestElasticSearchQueryBuilder(t *testing.T) {
+  Convey("Elasticserach QueryBuilder query testing", t, func() {
 
-		Convey("Build test average metric with moving average", func() {
-			var testElasticsearchModelRequestJSON = `
+    Convey("Build test average metric with moving average", func() {
+      var testElasticsearchModelRequestJSON = `
 			{
 			      "bucketAggs": [
 			        {
@@ -67,34 +66,38 @@ func TestElasticserachQueryBuilder(t *testing.T) {
 			}
 			`
 
-			var testElasticsearchQueryJSON = `
+      var testElasticsearchQueryJSON = `
 			{
 			  "size": 0,
 			  "query": {
-			    "bool": {
-			      "filter": [
-			        {
-			          "range": {
-			            "timestamp": {
-			              "gte": "<FROM_TIMESTAMP>",
-			              "lte": "<TO_TIMESTAMP>",
-			              "format": "epoch_millis"
-			            }
-			          }
-			        },
-			        {
-			          "query_string": {
-			            "analyze_wildcard": true,
-			            "query": "(test:query) AND (name:sample)"
-			          }
-			        }
-			      ]
-			    }
-			  },
+          "filtered": {
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "(test:query) AND (name:sample)"
+              }
+            },
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "range": {
+                      "timestamp": {
+                        "gte":"<FROM_TIMESTAMP>",
+                        "lte":"<TO_TIMESTAMP>",
+                        "format":"epoch_millis"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
 			  "aggs": {
 			    "2": {
 			      "date_histogram": {
-			        "interval": "5s",
+			        "interval": "200ms",
 			        "field": "timestamp",
 			        "min_doc_count": 0,
 			        "extended_bounds": {
@@ -125,48 +128,48 @@ func TestElasticserachQueryBuilder(t *testing.T) {
 			  }
 			}`
 
-			model := &RequestModel{}
+      model := &RequestModel{}
 
-			err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
-			So(err, ShouldBeNil)
+      err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
+      So(err, ShouldBeNil)
 
-			testTimeRange := &tsdb.TimeRange{
-				From: "5m",
-				To:   "now",
-				Now:  time.Now(),
-			}
+      testTimeRange := &tsdb.TimeRange{
+        From: "5m",
+        To:   "now",
+        Now:  time.Now(),
+      }
 
-			queryJSON, err := model.buildQueryJSON(testTimeRange)
-			So(err, ShouldBeNil)
+      queryJSON, err := model.buildQueryJSON(testTimeRange)
+      So(err, ShouldBeNil)
 
-			var queryExpectedJSONInterface, queryJSONInterface interface{}
+      var queryExpectedJSONInterface, queryJSONInterface interface{}
 
-			err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
-			So(err, ShouldBeNil)
+      err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
+      So(err, ShouldBeNil)
 
-			testElasticsearchQueryJSON = strings.Replace(
-				testElasticsearchQueryJSON,
-				"<FROM_TIMESTAMP>",
-				convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
-				-1,
-			)
+      testElasticsearchQueryJSON = strings.Replace(
+        testElasticsearchQueryJSON,
+        "<FROM_TIMESTAMP>",
+        convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
+        -1,
+      )
 
-			testElasticsearchQueryJSON = strings.Replace(
-				testElasticsearchQueryJSON,
-				"<TO_TIMESTAMP>",
-				convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
-				-1,
-			)
+      testElasticsearchQueryJSON = strings.Replace(
+        testElasticsearchQueryJSON,
+        "<TO_TIMESTAMP>",
+        convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
+        -1,
+      )
 
-			err = json.Unmarshal([]byte(testElasticsearchQueryJSON), &queryExpectedJSONInterface)
-			So(err, ShouldBeNil)
+      err = json.Unmarshal([]byte(testElasticsearchQueryJSON), &queryExpectedJSONInterface)
+      So(err, ShouldBeNil)
 
-			result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
-			So(result, ShouldBeTrue)
-		})
+      result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
+      So(result, ShouldBeTrue)
+    })
 
-		Convey("Test Wildcards and Quotes", func() {
-			testRequestModelJSON := `
+    Convey("Test Wildcards and Quotes", func() {
+      testRequestModelJSON := `
 			{
 				"alias": "New",
 				"bucketAggs": [{
@@ -185,28 +188,34 @@ func TestElasticserachQueryBuilder(t *testing.T) {
 				"timeField": "timestamp"
 			}`
 
-			expectedResultJSON := `
+      expectedResultJSON := `
 			{
 				"size": 0,
 				"query": {
-					"bool": {
-						"filter": [{
-							"range": {
-								"timestamp": {
-									"gte": "<FROM_TIMESTAMP>",
-									"lte": "<TO_TIMESTAMP>",
-									"format": "epoch_millis"
-								}
-							}
-						},
-						{
-							"query_string": {
-								"analyze_wildcard": true,
-								"query": "scope:$location.leagueconnect.api AND name:*CreateRegistration AND name:\"*.201-responses.rate\""
-							}
-						}]
-					}
-				},
+          "filtered": {
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "scope:$location.leagueconnect.api AND name:*CreateRegistration AND name:\"*.201-responses.rate\""
+              }
+            },
+            "filter": {
+              "bool": {
+                "must": [
+                  {
+                    "range": {
+                      "timestamp": {
+                        "gte":"<FROM_TIMESTAMP>",
+                        "lte":"<TO_TIMESTAMP>",
+                        "format":"epoch_millis"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
 				"aggs": {
 					"2": {
 						"aggs": {
@@ -227,80 +236,44 @@ func TestElasticserachQueryBuilder(t *testing.T) {
 					}
 				}
 			}`
-			model := &RequestModel{}
+      model := &RequestModel{}
 
-			err := json.Unmarshal([]byte(testRequestModelJSON), model)
-			So(err, ShouldBeNil)
+      err := json.Unmarshal([]byte(testRequestModelJSON), model)
+      So(err, ShouldBeNil)
 
-			testTimeRange := &tsdb.TimeRange{
-				From: "5m",
-				To:   "now",
-				Now:  time.Now(),
-			}
+      testTimeRange := &tsdb.TimeRange{
+        From: "5m",
+        To:   "now",
+        Now:  time.Now(),
+      }
 
-			queryJSON, err := model.buildQueryJSON(testTimeRange)
-			So(err, ShouldBeNil)
+      queryJSON, err := model.buildQueryJSON(testTimeRange)
+      So(err, ShouldBeNil)
 
-			expectedResultJSON = strings.Replace(
-				expectedResultJSON,
-				"<FROM_TIMESTAMP>",
-				convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
-				-1,
-			)
+      expectedResultJSON = strings.Replace(
+        expectedResultJSON,
+        "<FROM_TIMESTAMP>",
+        convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
+        -1,
+      )
 
-			expectedResultJSON = strings.Replace(
-				expectedResultJSON,
-				"<TO_TIMESTAMP>",
-				convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
-				-1,
-			)
+      expectedResultJSON = strings.Replace(
+        expectedResultJSON,
+        "<TO_TIMESTAMP>",
+        convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
+        -1,
+      )
 
-			var queryExpectedJSONInterface, queryJSONInterface interface{}
+      var queryExpectedJSONInterface, queryJSONInterface interface{}
 
-			err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
-			So(err, ShouldBeNil)
+      err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
+      So(err, ShouldBeNil)
 
-			err = json.Unmarshal([]byte(expectedResultJSON), &queryExpectedJSONInterface)
-			So(err, ShouldBeNil)
+      err = json.Unmarshal([]byte(expectedResultJSON), &queryExpectedJSONInterface)
+      So(err, ShouldBeNil)
 
-			result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
-			So(result, ShouldBeTrue)
-		})
-
-		Convey("Test Term Aggregate Query", func() {
-			testQueryJSON := `{
-			"bucketAggs":[
-			{
-			"field":"name_raw","id":"4","settings":
-			{"order":"desc","orderBy":"_term","size":"10"},"type":"terms"},
-			{"field":"rfc460Timestamp","id":"2",
-			"settings":{"interval":"1m","min_doc_count":0,"trimEdges":0},"type":"date_histogram"}],
-			"dsType":"elasticsearch",
-			"filters":[{"boolOp":"AND","not":false,"type":"rfc190Scope","value":"*.hmp.metricsd"},
-			{"boolOp":"AND","not":false,"type":"name_raw","value":"builtin.general.*_instance_count"}],
-			"metricObject":{},"metrics":[{"field":"value","id":"1","meta":{},"options":{},"settings":{},"type":"sum"}],
-			"mode":0,"numToGraph":10,"prependHostName":false,
-			"query":"(rfc190Scope:*.hmp.metricsd) AND (name_raw:builtin.general.*_instance_count)",
-			"refId":"A","regexAlias":false,
-			"selectedApplication":"","selectedHost":"","selectedLocation":"",
-			"timeField":"rfc460Timestamp",useFullHostName":"","useQuery":false}`
-
-			//expectedResponseJSON = `{}``
-			model := &RequestModel{}
-
-			err := json.Unmarshal([]byte(testQueryJSON), model)
-			So(err, ShouldBeNil)
-
-			testTimeRange := &tsdb.TimeRange{
-				From: "5m",
-				To:   "now",
-				Now:  time.Now(),
-			}
-
-			queryJSON, err := model.buildQueryJSON(testTimeRange)
-			So(err, ShouldBeNil)
-
-			fmt.Println(queryJSON)
-		})
-	})
+      result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
+      So(result, ShouldBeTrue)
+    })
+  })
 }

--- a/pkg/tsdb/elasticsearch/query_builder_test.go
+++ b/pkg/tsdb/elasticsearch/query_builder_test.go
@@ -1,221 +1,221 @@
 package elasticsearch
 
 import (
-  "encoding/json"
-  "reflect"
-  "strings"
-  "testing"
-  "time"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
 
-  "github.com/grafana/grafana/pkg/tsdb"
-  . "github.com/smartystreets/goconvey/convey"
+	"github.com/grafana/grafana/pkg/tsdb"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestElasticSearchQueryBuilder(t *testing.T) {
-  Convey("Elasticserach QueryBuilder query testing", t, func() {
+	Convey("Elasticsearch QueryBuilder query testing", t, func() {
 
-    Convey("Build test average metric with moving average", func() {
-      var testElasticsearchModelRequestJSON = `
+		Convey("Build test average metric with moving average", func() {
+			var testElasticsearchModelRequestJSON = `
 			{
-			      "bucketAggs": [
-			        {
-			          "field": "timestamp",
-			          "id": "2",
-			          "settings": {
-			            "interval": "auto",
-			            "min_doc_count": 0,
-			            "trimEdges": 0
-			          },
-			          "type": "date_histogram"
-			        }
-			      ],
-			      "dsType": "elasticsearch",
-			      "metrics": [
-			        {
-			          "field": "value",
-			          "id": "1",
-			          "inlineScript": "_value * 2",
-			          "meta": {
-
-			          },
-			          "settings": {
-			            "script": {
-			              "inline": "_value * 2"
-			            }
-			          },
-			          "type": "avg"
-			        },
-			        {
-			          "field": "1",
-			          "id": "3",
-			          "meta": {
-
-			          },
-			          "pipelineAgg": "1",
-			          "settings": {
-			            "minimize": false,
-			            "model": "simple",
-			            "window": 5
-			          },
-			          "type": "moving_avg"
-			        }
-			      ],
-			      "query": "(test:query) AND (name:sample)",
-			      "refId": "A",
-			      "timeField": "timestamp"
+				"bucketAggs": [
+					{
+						"field": "timestamp",
+						"id": "2",
+						"settings": {
+							"interval": "auto",
+							"min_doc_count": 0,
+							"trimEdges": 0
+						},
+						"type": "date_histogram"
+					}
+				],
+				"dsType": "elasticsearch",
+				"metrics": [
+					{
+						"field": "value",
+						"id": "1",
+						"inlineScript": "_value * 2",
+						"meta": {},
+						"settings": {
+							"script": {
+								"inline": "_value * 2"
+							}
+						},
+						"type": "avg"
+					},
+					{
+						"field": "1",
+						"id": "3",
+						"meta": {},
+						"pipelineAgg": "1",
+						"settings": {
+							"minimize": false,
+							"model": "simple",
+							"window": 5
+						},
+						"type": "moving_avg"
+					}
+				],
+				"query": "(test:query) AND (name:sample)",
+				"refId": "A",
+				"timeField": "timestamp"
 			}
 			`
 
-      var testElasticsearchQueryJSON = `
+			var testElasticsearchQueryJSON = `
 			{
-			  "size": 0,
-			  "query": {
-          "filtered": {
-            "query": {
-              "query_string": {
-                "analyze_wildcard": true,
-                "query": "(test:query) AND (name:sample)"
-              }
-            },
-            "filter": {
-              "bool": {
-                "must": [
-                  {
-                    "range": {
-                      "timestamp": {
-                        "gte":"<FROM_TIMESTAMP>",
-                        "lte":"<TO_TIMESTAMP>",
-                        "format":"epoch_millis"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
-			  "aggs": {
-			    "2": {
-			      "date_histogram": {
-			        "interval": "200ms",
-			        "field": "timestamp",
-			        "min_doc_count": 0,
-			        "extended_bounds": {
-			          "min": "<FROM_TIMESTAMP>",
-			          "max": "<TO_TIMESTAMP>"
-			        },
-			        "format": "epoch_millis"
-			      },
-			      "aggs": {
-			        "1": {
-			          "avg": {
-			            "field": "value",
-				            "script": {
-				              "inline": "_value * 2"
-				            }
-			          }
-			        },
-			        "3": {
-			          "moving_avg": {
-			            "buckets_path": "1",
-			            "window": 5,
-			            "model": "simple",
-			            "minimize": false
-			          }
-			        }
-			      }
-			    }
-			  }
+				"size": 0,
+				"query": {
+					"filtered": {
+						"query": {
+							"query_string": {
+								"analyze_wildcard": true,
+								"query": "(test:query) AND (name:sample)"
+							}
+						},
+						"filter": {
+							"bool": {
+								"must": [
+									{
+										"range": {
+											"timestamp": {
+												"gte": "<FROM_TIMESTAMP>",
+												"lte": "<TO_TIMESTAMP>",
+												"format": "epoch_millis"
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				"aggs": {
+					"2": {
+						"date_histogram": {
+							"interval": "200ms",
+							"field": "timestamp",
+							"min_doc_count": 0,
+							"extended_bounds": {
+								"min": "<FROM_TIMESTAMP>",
+								"max": "<TO_TIMESTAMP>"
+							},
+							"format": "epoch_millis"
+						},
+						"aggs": {
+							"1": {
+								"avg": {
+									"field": "value",
+									"script": {
+										"inline": "_value * 2"
+									}
+								}
+							},
+							"3": {
+								"moving_avg": {
+									"buckets_path": "1",
+									"window": 5,
+									"model": "simple",
+									"minimize": false
+								}
+							}
+						}
+					}
+				}
 			}`
 
-      model := &RequestModel{}
+			model := &RequestModel{}
 
-      err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
-      So(err, ShouldBeNil)
+			err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
+			So(err, ShouldBeNil)
 
-      testTimeRange := &tsdb.TimeRange{
-        From: "5m",
-        To:   "now",
-        Now:  time.Now(),
-      }
+			testTimeRange := &tsdb.TimeRange{
+				From: "5m",
+				To:   "now",
+				Now:  time.Now(),
+			}
 
-      queryJSON, err := model.buildQueryJSON(testTimeRange)
-      So(err, ShouldBeNil)
+			queryJSON, err := model.buildQueryJSON(testTimeRange)
+			So(err, ShouldBeNil)
 
-      var queryExpectedJSONInterface, queryJSONInterface interface{}
+			var queryExpectedJSONInterface, queryJSONInterface interface{}
 
-      err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
-      So(err, ShouldBeNil)
+			err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
+			So(err, ShouldBeNil)
 
-      testElasticsearchQueryJSON = strings.Replace(
-        testElasticsearchQueryJSON,
-        "<FROM_TIMESTAMP>",
-        convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
-        -1,
-      )
+			testElasticsearchQueryJSON = strings.Replace(
+				testElasticsearchQueryJSON,
+				"<FROM_TIMESTAMP>",
+				convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
+				-1,
+			)
 
-      testElasticsearchQueryJSON = strings.Replace(
-        testElasticsearchQueryJSON,
-        "<TO_TIMESTAMP>",
-        convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
-        -1,
-      )
+			testElasticsearchQueryJSON = strings.Replace(
+				testElasticsearchQueryJSON,
+				"<TO_TIMESTAMP>",
+				convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
+				-1,
+			)
 
-      err = json.Unmarshal([]byte(testElasticsearchQueryJSON), &queryExpectedJSONInterface)
-      So(err, ShouldBeNil)
+			err = json.Unmarshal([]byte(testElasticsearchQueryJSON), &queryExpectedJSONInterface)
+			So(err, ShouldBeNil)
 
-      result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
-      So(result, ShouldBeTrue)
-    })
+			result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
+			So(result, ShouldBeTrue)
+		})
 
-    Convey("Test Wildcards and Quotes", func() {
-      testRequestModelJSON := `
+		Convey("Test Wildcards and Quotes", func() {
+			testRequestModelJSON := `
 			{
 				"alias": "New",
-				"bucketAggs": [{
-					"field": "timestamp",
-					"id": "2",
-					"type": "date_histogram"
-				}],
+				"bucketAggs": [
+					{
+						"field": "timestamp",
+						"id": "2",
+						"type": "date_histogram"
+					}
+				],
 				"dsType": "elasticsearch",
-				"metrics": [{
-					"type": "sum",
-					"field": "value",
-					"id": "1"
-				}],
+				"metrics": [
+					{
+						"type": "sum",
+						"field": "value",
+						"id": "1"
+					}
+				],
 				"query": "scope:$location.leagueconnect.api AND name:*CreateRegistration AND name:\"*.201-responses.rate\"",
 				"refId": "A",
 				"timeField": "timestamp"
 			}`
 
-      expectedResultJSON := `
+			expectedResultJSON := `
 			{
 				"size": 0,
 				"query": {
-          "filtered": {
-            "query": {
-              "query_string": {
-                "analyze_wildcard": true,
-                "query": "scope:$location.leagueconnect.api AND name:*CreateRegistration AND name:\"*.201-responses.rate\""
-              }
-            },
-            "filter": {
-              "bool": {
-                "must": [
-                  {
-                    "range": {
-                      "timestamp": {
-                        "gte":"<FROM_TIMESTAMP>",
-                        "lte":"<TO_TIMESTAMP>",
-                        "format":"epoch_millis"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
+					"filtered": {
+						"query": {
+							"query_string": {
+								"analyze_wildcard": true,
+								"query": "scope:$location.leagueconnect.api AND name:*CreateRegistration AND name:\"*.201-responses.rate\""
+							}
+						},
+						"filter": {
+							"bool": {
+								"must": [
+									{
+										"range": {
+											"timestamp": {
+												"gte": "<FROM_TIMESTAMP>",
+												"lte": "<TO_TIMESTAMP>",
+												"format": "epoch_millis"
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				},
 				"aggs": {
 					"2": {
 						"aggs": {
@@ -236,44 +236,44 @@ func TestElasticSearchQueryBuilder(t *testing.T) {
 					}
 				}
 			}`
-      model := &RequestModel{}
+			model := &RequestModel{}
 
-      err := json.Unmarshal([]byte(testRequestModelJSON), model)
-      So(err, ShouldBeNil)
+			err := json.Unmarshal([]byte(testRequestModelJSON), model)
+			So(err, ShouldBeNil)
 
-      testTimeRange := &tsdb.TimeRange{
-        From: "5m",
-        To:   "now",
-        Now:  time.Now(),
-      }
+			testTimeRange := &tsdb.TimeRange{
+				From: "5m",
+				To:   "now",
+				Now:  time.Now(),
+			}
 
-      queryJSON, err := model.buildQueryJSON(testTimeRange)
-      So(err, ShouldBeNil)
+			queryJSON, err := model.buildQueryJSON(testTimeRange)
+			So(err, ShouldBeNil)
 
-      expectedResultJSON = strings.Replace(
-        expectedResultJSON,
-        "<FROM_TIMESTAMP>",
-        convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
-        -1,
-      )
+			expectedResultJSON = strings.Replace(
+				expectedResultJSON,
+				"<FROM_TIMESTAMP>",
+				convertTimeToUnixNano(testTimeRange.From, testTimeRange.Now),
+				-1,
+			)
 
-      expectedResultJSON = strings.Replace(
-        expectedResultJSON,
-        "<TO_TIMESTAMP>",
-        convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
-        -1,
-      )
+			expectedResultJSON = strings.Replace(
+				expectedResultJSON,
+				"<TO_TIMESTAMP>",
+				convertTimeToUnixNano(testTimeRange.To, testTimeRange.Now),
+				-1,
+			)
 
-      var queryExpectedJSONInterface, queryJSONInterface interface{}
+			var queryExpectedJSONInterface, queryJSONInterface interface{}
 
-      err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
-      So(err, ShouldBeNil)
+			err = json.Unmarshal([]byte(queryJSON), &queryJSONInterface)
+			So(err, ShouldBeNil)
 
-      err = json.Unmarshal([]byte(expectedResultJSON), &queryExpectedJSONInterface)
-      So(err, ShouldBeNil)
+			err = json.Unmarshal([]byte(expectedResultJSON), &queryExpectedJSONInterface)
+			So(err, ShouldBeNil)
 
-      result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
-      So(result, ShouldBeTrue)
-    })
-  })
+			result := reflect.DeepEqual(queryExpectedJSONInterface, queryJSONInterface)
+			So(result, ShouldBeTrue)
+		})
+	})
 }


### PR DESCRIPTION
Changing the elasticsearch query builder for alerting backend to match the format for query builder in frontend logic. Switching base template, and adding logic for creating appropriate Elasticsearch bucket aggregations.