### PR TITLE
ignore hidden elasticsearch metrics for alert

### DIFF
--- a/pkg/tsdb/elasticsearch/metric.go
+++ b/pkg/tsdb/elasticsearch/metric.go
@@ -24,6 +24,17 @@ type Name struct {
 // NameMap used to store overriden names from query context
 type NameMap map[string]Name
 
+// FilterMap provides the alert query filter status for Metrics; based on visible status on dashboard
+type FilterMap map[string]bool
+
+// Hide returns true if a metric should be hidden from check
+func (f FilterMap) Hide(key string) bool {
+	if hide, ok := f[key]; ok {
+		return hide
+	}
+	return false
+}
+
 // GetName returns the complete name, including any referenced names
 func (names NameMap) GetName(reference string) string {
 	if name, ok := names[reference]; ok {

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -154,7 +154,7 @@ func TestElasticserachQueryParser(t *testing.T) {
 				Value:     "Moving Average",
 				Reference: "1",
 			}
-			queryResult, err := parseQueryResult([]byte(testResponseJSON), names)
+			queryResult, err := parseQueryResult([]byte(testResponseJSON), names, FilterMap{})
 
 			So(err, ShouldBeNil)
 			So(queryResult, ShouldNotBeNil)
@@ -167,12 +167,25 @@ func TestElasticserachQueryParser(t *testing.T) {
 				Value: "Test Name",
 			}
 
-			queryResult, err := parseQueryResult([]byte(testRecursiveResponseJSON), names)
+			queryResult, err := parseQueryResult([]byte(testRecursiveResponseJSON), names, FilterMap{})
 
 			So(err, ShouldBeNil)
 			So(queryResult, ShouldNotBeNil)
 			So(len(queryResult.Series), ShouldEqual, 1)
 			So(queryResult.Series[0].Name, ShouldEqual, "Test Name")
+		})
+
+		Convey("Parse ElasticSearch Nested Query Results With Filter", func() {
+			names := NameMap{}
+			names["4"] = Name{
+				Value: "Test Name",
+			}
+
+			queryResult, err := parseQueryResult([]byte(testRecursiveResponseJSON), names, FilterMap{"4": true})
+
+			So(err, ShouldBeNil)
+			So(queryResult, ShouldNotBeNil)
+			So(len(queryResult.Series), ShouldEqual, 0)
 		})
 	})
 }

--- a/pkg/tsdb/elasticsearch/types.go
+++ b/pkg/tsdb/elasticsearch/types.go
@@ -11,6 +11,7 @@ type BucketAggregate struct {
 // Metric defines the metric being requested from elasticsearch
 type Metric struct {
 	Field             string                 `json:"field"`
+	Hide              bool                   `json:"hide"`
 	ID                string                 `json:"id"`
 	Meta              interface{}            `json:"meta"`
 	PipelineAggregate string                 `json:"pipelineAgg"`


### PR DESCRIPTION
Need to filter 'hidden' metrics to support more complex alerts like derivatives/moving avgs/etc...