### PR TITLE
Use query_then_fetch

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -202,7 +202,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         var queryObj = this.queryBuilder.build(target, adhocFilters, queryString);
         var esQuery = angular.toJson(queryObj);
 
-        var searchType = (queryObj.size === 0 && this.esVersion < 5) ? 'count' : 'query_then_fetch';
+        var searchType = 'query_then_fetch';
         var header = this.getQueryHeader(searchType, options.range.from, options.range.to);
         payload +=  header + '\n';
 
@@ -298,7 +298,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
 
     this.getTerms = function(queryDef) {
       var range = timeSrv.timeRange();
-      var searchType = this.esVersion >= 5 ? 'query_then_fetch' : 'count' ;
+      var searchType = 'query_then_fetch';
       var header = this.getQueryHeader(searchType, range.from, range.to);
       var esQuery = angular.toJson(this.queryBuilder.getTermsQuery(queryDef));
 


### PR DESCRIPTION
## Details

Removed search_type count to prevent elastic search from locking on each query. Reading the elastic search documentation, when size=0, count and query then fetch should match the same set of documents.

https://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-request-search-type.html#count

The default search_type is query then fetch if omitted. We tested locally with a couple of queries and verified that the expected result format is the same as what we had previously.