### PR TITLE
Adding support for ES5

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -124,6 +124,16 @@ func (e *ElasticsearchExecutor) buildRequest(queryInfo *tsdb.Query, timeRange *t
 		return nil, err
 	}
 
+  esVersionStr, err := queryInfo.DataSource.JsonData.Get("esVersion").String()
+  if err != nil {
+    return nil, err
+  }
+
+  esRequestModel.ESVersion, err = strconv.ParseFloat(esVersionStr, 64)
+  if err != nil {
+    return nil, err
+  }
+
 	esRequestJSON, err := esRequestModel.buildQueryJSON(timeRange)
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -124,12 +124,7 @@ func (e *ElasticsearchExecutor) buildRequest(queryInfo *tsdb.Query, timeRange *t
 		return nil, err
 	}
 
-	esVersionStr, err := queryInfo.DataSource.JsonData.Get("esVersion").String()
-	if err != nil {
-		return nil, err
-	}
-
-	esRequestModel.ESVersion, err = strconv.ParseFloat(esVersionStr, 64)
+	esRequestModel.ESVersion, err = queryInfo.DataSource.JsonData.Get("esVersion").Float64()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -124,15 +124,15 @@ func (e *ElasticsearchExecutor) buildRequest(queryInfo *tsdb.Query, timeRange *t
 		return nil, err
 	}
 
-  esVersionStr, err := queryInfo.DataSource.JsonData.Get("esVersion").String()
-  if err != nil {
-    return nil, err
-  }
+	esVersionStr, err := queryInfo.DataSource.JsonData.Get("esVersion").String()
+	if err != nil {
+		return nil, err
+	}
 
-  esRequestModel.ESVersion, err = strconv.ParseFloat(esVersionStr, 64)
-  if err != nil {
-    return nil, err
-  }
+	esRequestModel.ESVersion, err = strconv.ParseFloat(esVersionStr, 64)
+	if err != nil {
+		return nil, err
+	}
 
 	esRequestJSON, err := esRequestModel.buildQueryJSON(timeRange)
 	if err != nil {

--- a/pkg/tsdb/elasticsearch/query_builder.go
+++ b/pkg/tsdb/elasticsearch/query_builder.go
@@ -64,7 +64,6 @@ var queryTemplateV5 = `
 	"aggs": {{ . | formatAggregates }}
 }`
 
-
 func convertTimeToUnixNano(rangeTime string, now time.Time) string {
 	if rangeTime == "now" {
 		rangeTime = "30s"
@@ -275,10 +274,10 @@ func (model *RequestModel) buildQueryJSON(timeRange *tsdb.TimeRange) (string, er
 		},
 	}
 
-  queryTemplate := queryTemplateV2
-  if (model.ESVersion >= 5) {
-    queryTemplate = queryTemplateV5
-  }
+	queryTemplate := queryTemplateV2
+	if model.ESVersion >= 5 {
+		queryTemplate = queryTemplateV5
+	}
 	t, err := template.New("elasticsearchQuery").Funcs(funcMap).Parse(queryTemplate)
 	if err != nil {
 		return "", err

--- a/pkg/tsdb/elasticsearch/query_builder_test.go
+++ b/pkg/tsdb/elasticsearch/query_builder_test.go
@@ -343,8 +343,8 @@ func TestElasticSearchQueryBuilder(t *testing.T) {
 }
 
 func TestElasticSearchQueryBuilderRespectsESVersions(t *testing.T) {
-  Convey("Test versioning specification in RequestModel", t, func() {
-    var testElasticsearchModelRequestJSON = `
+	Convey("Test versioning specification in RequestModel", t, func() {
+		var testElasticsearchModelRequestJSON = `
 			{
 				"bucketAggs": [
           {
@@ -374,35 +374,35 @@ func TestElasticSearchQueryBuilderRespectsESVersions(t *testing.T) {
 			}
 			`
 
-    // Non-versioned RequestModel should default to ES2
-    model := &RequestModel{}
+		// Non-versioned RequestModel should default to ES2
+		model := &RequestModel{}
 
-    err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
-    So(err, ShouldBeNil)
+		err := json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
+		So(err, ShouldBeNil)
 
-    testTimeRange := &tsdb.TimeRange{
-      From: "5m",
-      To:   "now",
-      Now:  time.Now(),
-    }
+		testTimeRange := &tsdb.TimeRange{
+			From: "5m",
+			To:   "now",
+			Now:  time.Now(),
+		}
 
-    queryJSON, err := model.buildQueryJSON(testTimeRange)
-    So(err, ShouldBeNil)
+		queryJSON, err := model.buildQueryJSON(testTimeRange)
+		So(err, ShouldBeNil)
 
-    So(queryJSON, ShouldContainSubstring, "filtered")
+		So(queryJSON, ShouldContainSubstring, "filtered")
 
-    // Versioned ES5 should not use "filtered" keyword
+		// Versioned ES5 should not use "filtered" keyword
 
-    model = &RequestModel{}
+		model = &RequestModel{}
 
-    err = json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
-    So(err, ShouldBeNil)
+		err = json.Unmarshal([]byte(testElasticsearchModelRequestJSON), model)
+		So(err, ShouldBeNil)
 
-    model.ESVersion = 5.0
+		model.ESVersion = 5.0
 
-    queryJSON, err = model.buildQueryJSON(testTimeRange)
-    So(err, ShouldBeNil)
+		queryJSON, err = model.buildQueryJSON(testTimeRange)
+		So(err, ShouldBeNil)
 
-    So(queryJSON, ShouldNotContainSubstring, "filtered")
-  })
+		So(queryJSON, ShouldNotContainSubstring, "filtered")
+	})
 }

--- a/pkg/tsdb/elasticsearch/types.go
+++ b/pkg/tsdb/elasticsearch/types.go
@@ -23,7 +23,7 @@ type Metric struct {
 type RequestModel struct {
 	BucketAggregates []BucketAggregate `json:"bucketAggs"`
 	DatasourceType   string            `json:"dsType"`
-  ESVersion        float64           `json:"esVersion"`
+	ESVersion        float64           `json:"esVersion"`
 	Metrics          []Metric          `json:"metrics"`
 	Query            string            `json:"query"`
 	RefID            string            `json:"refId"`

--- a/pkg/tsdb/elasticsearch/types.go
+++ b/pkg/tsdb/elasticsearch/types.go
@@ -23,6 +23,7 @@ type Metric struct {
 type RequestModel struct {
 	BucketAggregates []BucketAggregate `json:"bucketAggs"`
 	DatasourceType   string            `json:"dsType"`
+  ESVersion        float64           `json:"esVersion"`
 	Metrics          []Metric          `json:"metrics"`
 	Query            string            `json:"query"`
 	RefID            string            `json:"refId"`


### PR DESCRIPTION
@beardface 

Adding compliance for ES5 versioned queries. Looks at esVersion and chooses between old ES2 query or ES5 query templates.