### PR TITLE
Sanitizing Backend Alert Data

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -191,7 +191,6 @@ func (e *ElasticsearchExecutor) Execute(ctx context.Context, queries tsdb.QueryS
 		}
 
 		result.QueryResults[q.RefId], err = parseQueryResult(rBody, getPreferredNamesForQueries(q), getFilteredMetrics(q))
-    fmt.Printf("%+v\n", *(result.QueryResults[q.RefId].Series[0]))
 		if err != nil {
 			return result.WithError(err)
 		}

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -191,6 +191,7 @@ func (e *ElasticsearchExecutor) Execute(ctx context.Context, queries tsdb.QueryS
 		}
 
 		result.QueryResults[q.RefId], err = parseQueryResult(rBody, getPreferredNamesForQueries(q), getFilteredMetrics(q))
+    fmt.Printf("%+v\n", *(result.QueryResults[q.RefId].Series[0]))
 		if err != nil {
 			return result.WithError(err)
 		}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -137,9 +137,16 @@ func parseQueryResult(response []byte, preferredNames NameMap, resultFilter Filt
 
 	for id, series := range timeSeries {
 		if len(timeSeries) > 0 && id != "doc_count" || len(timeSeries) == 1 && id == "doc_count" {
+      // Remove all points that have null data for either coordinate value
+      nonNullPoints := make(tsdb.TimeSeriesPoints, 0)
+      for _, v := range series {
+        if (v[0].Ptr() != nil && v[1].Ptr() != nil) {
+          nonNullPoints = append(nonNullPoints, v)
+        }
+      }
 			ts := &tsdb.TimeSeries{
 				Name:   id,
-				Points: series,
+				Points: nonNullPoints,
 			}
 			queryRes.Series = append(queryRes.Series, ts)
 		}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -152,6 +152,9 @@ func parseQueryResult(response []byte, preferredNames NameMap, resultFilter Filt
 		}
 	}
 
+  // Auto-cropping both ends for Riot specific HMP 2.0 per-minute calculations. We only want whole datapoints.
+  queryRes.Series = queryRes.Series[1:-1]
+
 	return queryRes, nil
 }
 

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -137,13 +137,22 @@ func parseQueryResult(response []byte, preferredNames NameMap, resultFilter Filt
 
 	for id, series := range timeSeries {
 		if len(timeSeries) > 0 && id != "doc_count" || len(timeSeries) == 1 && id == "doc_count" {
-      // Remove all points that have null data for either coordinate value
-      nonNullPoints := make(tsdb.TimeSeriesPoints, 0)
-      for _, v := range series {
-        if (v[0].Ptr() != nil && v[1].Ptr() != nil) {
-          nonNullPoints = append(nonNullPoints, v)
-        }
-      }
+			// Remove all points that have null data for either coordinate value
+			nonNullPoints := make(tsdb.TimeSeriesPoints, 0)
+			seenTimes := make(map[float64]bool)
+			for _, v := range series {
+				if v[0].Ptr() != nil && v[1].Ptr() != nil {
+					_, seenTime := seenTimes[v[1].Float64]
+					// Discard duplicate timestamps (Elasticsearch seems to return these occasionally). Important to do so before
+					// cropping.
+					if !seenTime {
+						nonNullPoints = append(nonNullPoints, v)
+						seenTimes[v[1].Float64] = true
+					}
+				}
+			}
+			// Auto-cropping both ends for Riot specific HMP 2.0 per-minute calculations. We only want whole datapoints.
+			nonNullPoints = nonNullPoints[1 : len(nonNullPoints)-1]
 			ts := &tsdb.TimeSeries{
 				Name:   id,
 				Points: nonNullPoints,
@@ -151,9 +160,6 @@ func parseQueryResult(response []byte, preferredNames NameMap, resultFilter Filt
 			queryRes.Series = append(queryRes.Series, ts)
 		}
 	}
-
-  // Auto-cropping both ends for Riot specific HMP 2.0 per-minute calculations. We only want whole datapoints.
-  queryRes.Series = queryRes.Series[1:-1]
 
 	return queryRes, nil
 }


### PR DESCRIPTION
@beardface 

Removing:
- Null datapoints (either value or timestamp)
- Bookend datapoints (because they may capture partial data, not a full minutes worth of data)
- Duplicate datapoints (because ES can sometimes return multiple datapoints with the same timestamp and value, and duplications should be removed before trimming bookends)